### PR TITLE
[APIS-8] Docker image with jdk11 and datadog agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - ./build.sh build squid-ssl
         - ./build.sh push squid-ssl
     - stage: deploy
-        name: jdk11-datadog-agent
+        name: 11.0.7-jre-slim-buster-datadog-agent
         script:
           - ./build.sh pull jdk11-datadog-agent
           - ./build.sh build jdk11-datadog-agent

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,9 @@ jobs:
         - ./build.sh pull squid-ssl
         - ./build.sh build squid-ssl
         - ./build.sh push squid-ssl
+    - stage: deploy
+        name: jdk11-datadog-agent
+        script:
+          - ./build.sh pull jdk11-datadog-agent
+          - ./build.sh build jdk11-datadog-agent
+          - ./build.sh push jdk11-datadog-agent

--- a/README.md
+++ b/README.md
@@ -89,3 +89,18 @@ shown):
 
 Alternatively, a custom config file can be bind-mounted to
 `/etc/squid/squid.conf` while passing `SQUID_CUSTOM_CONFIG=1` as an env var.
+
+## cobli/jdk11-datadog-agent
+
+Base: openjdk:11.0.7-jre-slim-buster
+
+This is a _Java_ image with the datadog agent configured 
+
+It downloads the datadog agent and adds it to the _JAVA_OPTS_ environment variable.
+You can override the _JAVA_OPTS_, but remember to configure the agent by adding the parameter: `-javaagent:/opt/java-app/dd-java-agent.jar`.  
+
+To configure the DataDog agent, you need to set its environment variables. For example:
+- `DD_ENV: prod`
+- `DD_TRACE_ENABLED: "false"`
+- `DD_AGENT_HOST: ${YOUR_AGENT_HOST_URL}`
+- `DD_SERVICE: ${YOUR_SERVICE_NAME}`

--- a/jdk11-datadog-agent/Dockerfile
+++ b/jdk11-datadog-agent/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:11.0.7-jre-slim-buster
+
+### Datadog agent config
+ENV DD_TRACE_ENABLED="false"
+ARG DD_REPO_BASE_URL=https://repository.sonatype.org/service/local/repositories
+ARG DD_VERSION=0.56.0
+
+WORKDIR /opt/java-app/
+
+RUN  apt-get update \
+  && apt-get install --no-install-recommends -y wget=1.20.1-1.1 \
+  && wget -O dd-java-agent.jar \
+    ${DD_REPO_BASE_URL}/central-proxy/content/com/datadoghq/dd-java-agent/${DD_VERSION}/dd-java-agent-${DD_VERSION}.jar \
+  && apt-get remove --purge -y wget \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_OPTS="-javaagent:/opt/java-app/dd-java-agent.jar"
+
+LABEL io.buildpacks.stack.id=io.buildpacks.stacks.bionic"
+

--- a/jdk11-datadog-agent/Dockerfile
+++ b/jdk11-datadog-agent/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:11.0.7-jre-slim-buster
 ### Datadog agent config
 ENV DD_TRACE_ENABLED="false"
 ARG DD_REPO_BASE_URL=https://repository.sonatype.org/service/local/repositories
-ARG DD_VERSION=0.56.0
+ARG DD_VERSION=0.58.0
 
 WORKDIR /opt/java-app/
 
@@ -17,4 +17,3 @@ RUN  apt-get update \
 ENV JAVA_OPTS="-javaagent:/opt/java-app/dd-java-agent.jar"
 
 LABEL io.buildpacks.stack.id=io.buildpacks.stacks.bionic"
-


### PR DESCRIPTION
This image is to be used with the [bootBuildImage](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/gradle-plugin/reference/html/#build-image) gradle plugin in the fusca-api project. See the [pull request](https://github.com/Cobliteam/fusca/pull/11/files). 

This plugin builds the docker image for us. So, the only way to configure the datadog agent is providing a `runImage`. We didn't want to create our own `Dockerfile` since this plugin seems to be optimising things we don't even know exists 🙈 