### PR TITLE
update dd agent and java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - ./build.sh build squid-ssl
         - ./build.sh push squid-ssl
     - stage: deploy
-      name: 11.0.7-jre-slim-buster-datadog-agent
+      name: 11.0.13-jre-slim-buster-datadog-agent
       script:
         - ./build.sh pull jdk11-datadog-agent
         - ./build.sh build jdk11-datadog-agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,11 +69,11 @@ services:
       cache_from:
         - ${DOCKER_REPO}/squid-ssl:latest
   jdk11-datadog-agent:
-    image: ${DOCKER_REPO}/jdk11-datadog-agent:11.0.7-jre-slim-buster-datadog-agent${DOCKER_REV_TAG:-}
+    image: ${DOCKER_REPO}/jdk11-datadog-agent:11.0.13-jre-slim-buster-datadog-agent${DOCKER_REV_TAG:-}
     build:
       context: jdk11-datadog-agent
       cache_from:
-        - ${DOCKER_REPO}/jdk11-datadog-agent:11.0.7-jre-slim-buster-datadog-agent
+        - ${DOCKER_REPO}/jdk11-datadog-agent:11.0.13-jre-slim-buster-datadog-agent
   flink:
     image: ${DOCKER_REPO}/flink:1.9.0-scala_2.11${DOCKER_REV_TAG:-}
     build:

--- a/jdk11-datadog-agent/Dockerfile
+++ b/jdk11-datadog-agent/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:11.0.7-jre-slim-buster
+FROM openjdk:11.0.13-jre-slim-buster
 
 ### Datadog agent config
 ENV DD_TRACE_ENABLED="false"
 ARG DD_REPO_BASE_URL=https://repository.sonatype.org/service/local/repositories
-ARG DD_VERSION=0.58.0
+ARG DD_VERSION=0.93.0
 
 WORKDIR /opt/java-app/
 


### PR DESCRIPTION
The main reason for this PR is to check if a simple DD agent upgrade could make Error Tracking works (and maybe freeing sentry from some apps)

Rigth now, we can see the error on [trace](https://app.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Aatlas-route-geofences-events%20status%3Aerror%20operation_name%3Ascheduled.call&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&filteredType=web&graphType=flamegraph&historicalData=true&messageDisplay=inline&showAllSpans=true&sort=desc&spanID=8712998121067739229&spanViewType=errors&streamTraces=true&timeHint=1643186860043&trace=AgAAAX6VkbALkrwpqwAAAAAAAAAYAAAAAEFYNlZrY0E0QUFEV0RhX3oxREtVd3M4YQAAACQAAAAAMDE3ZTk1OTMtODYxOS00MzRkLThkMDYtNTNmYWY4NzkyNzlh&traceID=1931857986501281906&start=1643186820000&end=1643186880000&paused=true), but not on Error Tracking.

I'm also upgrading java minor version (changelogs indicates only CVEs and bug fixes that does not affects our apps)

https://www.oracle.com/java/technologies/javase/11-0-8-relnotes.html
https://access.redhat.com/documentation/en-us/openjdk/11/pdf/release_notes_for_openjdk_11.0.9/index
https://access.redhat.com/documentation/en-us/openjdk/11/pdf/release_notes_for_openjdk_11.0.10/index
https://access.redhat.com/documentation/en-us/openjdk/11/pdf/release_notes_for_openjdk_11.0.11/index
https://access.redhat.com/documentation/en-us/openjdk/11/pdf/release_notes_for_openjdk_11.0.12/index
https://access.redhat.com/documentation/en-us/openjdk/11/pdf/release_notes_for_openjdk_11.0.13/index