### PR TITLE
chore: Adds multi architecture for flink images

### DIFF
--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -1,21 +1,67 @@
+FROM openjdk:11.0.16-slim-buster
+
 ARG FLINK_VERSION
 ARG SCALA_VERSION_MAJOR
 ARG SCALA_VERSION_MINOR
-ARG BASE_IMAGE=flink:$FLINK_VERSION-scala_$SCALA_VERSION_MAJOR.$SCALA_VERSION_MINOR
-
-FROM $BASE_IMAGE
-
-# datadog java agent arguments
-ARG DD_VERSION=0.73.0
+ARG DD_VERSION=0.107.1
+ARG GOSU_VERSION=1.11
 ARG FLINK_HOME=/opt/flink
 
-USER root
-WORKDIR /opt/flink
-RUN apt-get update \
-      && apt-get install -y --no-install-recommends jq gettext \
-      && rm -rf /var/lib/apt/lists/* \
-      && wget -O opt/dd-java-agent.jar \
-      https://github.com/DataDog/dd-trace-java/releases/download/v${DD_VERSION}/dd-java-agent-${DD_VERSION}.jar
+# Install dependencies
+ENV DD_VERSION=$DD_VERSION
+RUN set -ex; \
+  apt-get update; \
+  apt-get -y install wget libsnappy1v5 gnupg jq gettext libjemalloc-dev; \
+  rm -rf /var/lib/apt/lists/*; \
+  wget -O opt/dd-java-agent.jar \
+    https://github.com/DataDog/dd-trace-java/releases/download/v${DD_VERSION}/dd-java-agent-${DD_VERSION}.jar
+
+# Grab gosu for easy step-down from root
+ENV GOSU_VERSION=$GOSU_VERSION
+RUN set -ex; \
+  wget -nv -O /usr/local/bin/gosu \
+    https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture); \
+  wget -nv -O /usr/local/bin/gosu.asc \
+    https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc; \
+  export GNUPGHOME="$(mktemp -d)"; \
+  for server in ha.pool.sks-keyservers.net $(shuf -e \
+                          hkp://p80.pool.sks-keyservers.net:80 \
+                          keyserver.ubuntu.com \
+                          hkp://keyserver.ubuntu.com:80 \
+                          pgp.mit.edu) ; do \
+      gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+  done && \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+  gpgconf --kill all; \
+  rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+  chmod +x /usr/local/bin/gosu; \
+  gosu nobody true
+
+# Configure Flink version
+ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION_MAJOR}.${SCALA_VERSION_MINOR}.tgz \
+    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION_MAJOR}.${SCALA_VERSION_MINOR}.tgz.asc
+
+# Prepare environment
+ENV FLINK_HOME $FLINK_HOME
+ENV PATH=$FLINK_HOME/bin:$PATH
+RUN groupadd --system --gid=9999 flink && \
+    useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 COPY --chown=flink:flink scripts $FLINK_HOME/bin/cobli-scripts
-EXPOSE 8081 6122 6123 6124 6125
+WORKDIR $FLINK_HOME
+
+# Install Flink
+RUN set -ex; \
+  wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
+  \
+  tar -xf flink.tgz --strip-components=1; \
+  rm flink.tgz; \
+  \
+  chown -R flink:flink .;
+
 USER flink
+
+# Configure container
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+EXPOSE 8081 6122 6123 6124 6125
+CMD ["help"]

--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-slim-buster
+FROM openjdk:11.0.16-jre-slim-bullseye
 
 ARG FLINK_VERSION
 ARG SCALA_VERSION_MAJOR

--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -39,7 +39,8 @@ RUN set -ex; \
 
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION_MAJOR}.${SCALA_VERSION_MINOR}.tgz \
-    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION_MAJOR}.${SCALA_VERSION_MINOR}.tgz.asc
+    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION_MAJOR}.${SCALA_VERSION_MINOR}.tgz.asc \
+    CHECK_GPG=true
 
 # Prepare environment
 ENV FLINK_HOME $FLINK_HOME
@@ -47,11 +48,28 @@ ENV PATH=$FLINK_HOME/bin:$PATH
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 COPY --chown=flink:flink scripts $FLINK_HOME/bin/cobli-scripts
+COPY --chown=flink:flink get-gpg-key.sh $FLINK_HOME
 WORKDIR $FLINK_HOME
 
 # Install Flink
 RUN set -ex; \
+  . $FLINK_HOME/get-gpg-key.sh; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
+  \
+  if [ "$CHECK_GPG" = "true" ]; then \
+    wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    for server in ha.pool.sks-keyservers.net $(shuf -e \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
+    done && \
+    gpg --batch --verify flink.tgz.asc flink.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  fi; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \

--- a/flink/docker-entrypoint.sh
+++ b/flink/docker-entrypoint.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+COMMAND_STANDALONE="standalone-job"
+COMMAND_HISTORY_SERVER="history-server"
+
+# If unspecified, the hostname of the container is taken as the JobManager address
+JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-$(hostname -f)}
+CONF_FILE="${FLINK_HOME}/conf/flink-conf.yaml"
+
+drop_privs_cmd() {
+    if [ $(id -u) != 0 ]; then
+        # Don't need to drop privs if EUID != 0
+        return
+    elif [ -x /sbin/su-exec ]; then
+        # Alpine
+        echo su-exec flink
+    else
+        # Others
+        echo gosu flink
+    fi
+}
+
+copy_plugins_if_required() {
+  if [ -z "$ENABLE_BUILT_IN_PLUGINS" ]; then
+    return 0
+  fi
+
+  echo "Enabling required built-in plugins"
+  for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | tr ';' ' '); do
+    echo "Linking ${target_plugin} to plugin directory"
+    plugin_name=${target_plugin%.jar}
+
+    mkdir -p "${FLINK_HOME}/plugins/${plugin_name}"
+    if [ ! -e "${FLINK_HOME}/opt/${target_plugin}" ]; then
+      echo "Plugin ${target_plugin} does not exist. Exiting."
+      exit 1
+    else
+      ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"
+      echo "Successfully enabled ${target_plugin}"
+    fi
+  done
+}
+
+set_config_option() {
+  local option=$1
+  local value=$2
+
+  # escape periods for usage in regular expressions
+  local escaped_option=$(echo ${option} | sed -e "s/\./\\\./g")
+
+  # either override an existing entry, or append a new one
+  if grep -E "^${escaped_option}:.*" "${CONF_FILE}" > /dev/null; then
+        sed -i -e "s/${escaped_option}:.*/$option: $value/g" "${CONF_FILE}"
+  else
+        echo "${option}: ${value}" >> "${CONF_FILE}"
+  fi
+}
+
+prepare_configuration() {
+    set_config_option jobmanager.rpc.address ${JOB_MANAGER_RPC_ADDRESS}
+    set_config_option blob.server.port 6124
+    set_config_option query.server.port 6125
+
+    TASK_MANAGER_NUMBER_OF_TASK_SLOTS=${TASK_MANAGER_NUMBER_OF_TASK_SLOTS:-1}
+    set_config_option taskmanager.numberOfTaskSlots ${TASK_MANAGER_NUMBER_OF_TASK_SLOTS}
+
+    if [ -n "${FLINK_PROPERTIES}" ]; then
+        echo "${FLINK_PROPERTIES}" >> "${CONF_FILE}"
+    fi
+    envsubst < "${CONF_FILE}" > "${CONF_FILE}.tmp" && mv "${CONF_FILE}.tmp" "${CONF_FILE}"
+}
+
+maybe_enable_jemalloc() {
+    if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
+        export LD_PRELOAD=$LD_PRELOAD:/usr/lib/x86_64-linux-gnu/libjemalloc.so
+    fi
+}
+
+maybe_enable_jemalloc
+
+copy_plugins_if_required
+
+prepare_configuration
+
+args=("$@")
+if [ "$1" = "help" ]; then
+    printf "Usage: $(basename "$0") (jobmanager|${COMMAND_STANDALONE}|taskmanager|${COMMAND_HISTORY_SERVER})\n"
+    printf "    Or $(basename "$0") help\n\n"
+    printf "By default, Flink image adopts jemalloc as default memory allocator. This behavior can be disabled by setting the 'DISABLE_JEMALLOC' environment variable to 'true'.\n"
+    exit 0
+elif [ "$1" = "jobmanager" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Job Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/jobmanager.sh" start-foreground "${args[@]}"
+elif [ "$1" = ${COMMAND_STANDALONE} ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Job Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/standalone-job.sh" start-foreground "${args[@]}"
+elif [ "$1" = ${COMMAND_HISTORY_SERVER} ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting History Server"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/historyserver.sh" start-foreground "${args[@]}"
+elif [ "$1" = "taskmanager" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Task Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/taskmanager.sh" start-foreground "${args[@]}"
+fi
+
+args=("${args[@]}")
+
+# Running command in pass-through mode
+exec $(drop_privs_cmd) "${args[@]}"

--- a/flink/docker-entrypoint.sh
+++ b/flink/docker-entrypoint.sh
@@ -72,7 +72,14 @@ prepare_configuration() {
 
 maybe_enable_jemalloc() {
     if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
-        export LD_PRELOAD=$LD_PRELOAD:/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        ARCH=$(uname -m)
+        case $ARCH in
+            aarch64) ARCH="aarch64";;
+            arm64) ARCH="aarch64";;
+            x86) ARCH="x86_64";;
+            x86_64) ARCH="x86_64";;
+        esac
+        export LD_PRELOAD=$LD_PRELOAD:/usr/lib/$ARCH-linux-gnu/libjemalloc.so
     fi
 }
 

--- a/flink/get-gpg-key.sh
+++ b/flink/get-gpg-key.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ "$FLINK_VERSION" = "1.9.0" ]; then
+    gpg_key="1C1E2394D3194E1944613488F320986D35C33D6A"
+elif [ "$FLINK_VERSION" = "1.9.1" ]; then
+    gpg_key="E2C45417BED5C104154F341085BACB5AEFAE3202"
+elif [ "$FLINK_VERSION" = "1.9.2" ]; then
+    gpg_key="EF88474C564C7A608A822EEC3FF96A2057B6476C"
+elif [ "$FLINK_VERSION" = "1.9.3" ]; then
+    gpg_key="6B6291A8502BA8F0913AE04DDEB95B05BF075300"
+elif [ "$FLINK_VERSION" = "1.13.0" ]; then
+    gpg_key="31D2DD10BFC15A2D"
+elif [ "$FLINK_VERSION" = "1.13.1" ]; then
+    gpg_key="31D2DD10BFC15A2D"
+elif [ "$FLINK_VERSION" = "1.13.2" ]; then
+    gpg_key="78A306590F1081CC6794DC7F62DAD618E07CF996"
+elif [ "$FLINK_VERSION" = "1.13.3" ]; then
+    gpg_key="19F2195E1B4816D765A2C324C2EED7B111D464BA"
+elif [ "$FLINK_VERSION" = "1.13.4" ]; then
+    gpg_key="19F2195E1B4816D765A2C324C2EED7B111D464BA"
+elif [ "$FLINK_VERSION" = "1.13.5" ]; then
+    gpg_key="19F2195E1B4816D765A2C324C2EED7B111D464BA"
+elif [ "$FLINK_VERSION" = "1.13.6" ]; then
+    gpg_key="CCFA852FD039380AB3EC36D08C3FB007FE60DEFA"
+else
+    error "Missing GPG key ID for this release"
+fi
+
+export GPG_KEY=$gpg_key


### PR DESCRIPTION
Rewrites flink image from the ground up to support multiarch while building flink.

Things to do next:
- Try running a job with this image in both `amd64` and `arm64` platforms;
- Switch base image from openjdk (deprecated) to [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin).