### PR TITLE
chore(jdk): upgrading java and datadog agent versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Same as above, but for Ubuntu 16.04.
 
 ## cobli/jdk11-datadog-agent
 
-Base: openjdk:11.0.7-jre-slim-buster
+Base: openjdk:11.0.16-jre-slim-buster
 
 This is a _Java_ image with the datadog agent configured
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,11 +63,11 @@ services:
     depends_on:
       - ubuntu-init-18.04
   jdk11-datadog-agent:
-    image: ${DOCKER_REPO}/jdk11-datadog-agent:11.0.13-jre-slim-buster-datadog-agent${DOCKER_REV_TAG:-}
+    image: ${DOCKER_REPO}/jdk11-datadog-agent:11.0.16-jre-slim-buster-datadog-agent${DOCKER_REV_TAG:-}
     build:
       context: jdk11-datadog-agent
       cache_from:
-        - ${DOCKER_REPO}/jdk11-datadog-agent:11.0.13-jre-slim-buster-datadog-agent
+        - ${DOCKER_REPO}/jdk11-datadog-agent:11.0.16-jre-slim-buster-datadog-agent
   flink:
     image: ${DOCKER_REPO}/flink:1.13.6-scala_2.11${DOCKER_REV_TAG:-}
     build:

--- a/jdk11-datadog-agent/Dockerfile
+++ b/jdk11-datadog-agent/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:11.0.13-jre-slim-buster
+FROM openjdk:11.0.16-jre-slim-buster
 
 ### Datadog agent config
 ENV DD_TRACE_ENABLED="false"
 ARG DD_REPO_BASE_URL=https://repository.sonatype.org/service/local/repositories
-ARG DD_VERSION=0.93.0
+ARG DD_VERSION=0.110.0
 
 WORKDIR /opt/java-app/
 


### PR DESCRIPTION
This image is used by Spring projects, in a versioned way.

Just bumping minor java versions and datadog agent (mainly innocuous).